### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm start"

--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ Polish opensource multifunctional bot in [discord.js](https://discord.js.org) li
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fjuby210-PL%2Fbot.js.svg?type=large)](https://app.fossa.io/projects/git%2Bgithub.com%2Fjuby210-PL%2Fbot.js?ref=badge_large)
 
 [![FOSSA Status](https://app.fossa.io/api/projects/git%2Bgithub.com%2Fjuby210-PL%2Fbot.js.svg?type=small)](https://app.fossa.io/projects/git%2Bgithub.com%2Fjuby210-PL%2Fbot.js?ref=badge_small)
+[![Run on Repl.it](https://repl.it/badge/github/Juby210/bot.js)](https://repl.it/github/Juby210/bot.js)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).